### PR TITLE
Fix file finding on Windows

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -53,8 +53,4 @@ buildArtefactsPath root (Project version user repo) =
 
 
 findFiles :: FilePath -> IO [FilePath]
-findFiles = find (excludedDirs filePath) (filePath ~~? "**" </> "*.elmi")
-
-
-excludedDirs :: FindClause FilePath -> FindClause Bool
-excludedDirs path = path /~? "**" </> "*.elmo"
+findFiles = find (pure True) (extension ==? ".elmi")


### PR DESCRIPTION
Using elm-interface-json on Windows brought to light that elm-interface-to-json did not find any definitions. Appearantly this is because the globbing code did not find any files on windows. This change fixes that.